### PR TITLE
[HOTFIX], IISCRUM-3030, Maintenances, non-selectable small minutes.

### DIFF
--- a/public/app/features/dashboard/components/DashNav/IirisMaintenanceModal.tsx
+++ b/public/app/features/dashboard/components/DashNav/IirisMaintenanceModal.tsx
@@ -803,8 +803,8 @@ export class IirisMaintenanceModal extends PureComponent<Props, State> {
   populateMinuteSelector = (minuteInputObject: any, minuteValue: number) => {
     for (let i = 0; i < 60; i++) {
       minuteInputObject.options.push({
-        text: i < 10 ? '0' + i : '' + i,
-        value: i < 10 ? '0' + i : '' + i,
+        text: '' + i,
+        value: '' + i,
       });
     }
     const givenMinutes = minuteValue < 10 ? '0' + minuteValue : '' + minuteValue;

--- a/public/app/features/dashboard/components/DashNav/IirisMaintenanceModal.tsx
+++ b/public/app/features/dashboard/components/DashNav/IirisMaintenanceModal.tsx
@@ -807,7 +807,7 @@ export class IirisMaintenanceModal extends PureComponent<Props, State> {
         value: '' + i,
       });
     }
-    const givenMinutes = minuteValue < 10 ? '0' + minuteValue : '' + minuteValue;
+    const givenMinutes = '' + minuteValue;
     if (minuteInputObject.options.findIndex((item: any) => item.value === givenMinutes)) {
       minuteInputObject.value = givenMinutes;
     } else {


### PR DESCRIPTION
Other dropdown selections in maintenances do not have leading zeroes, so why should minutes? This only resulted in non-selectable small minutes.