### PR TITLE
[HOTFIX], IISCRUM-3036, Maintenances, double numbers in inputs.

### DIFF
--- a/public/app/features/dashboard/components/DashNav/IirisMaintenanceModal.tsx
+++ b/public/app/features/dashboard/components/DashNav/IirisMaintenanceModal.tsx
@@ -713,12 +713,14 @@ export class IirisMaintenanceModal extends PureComponent<Props, State> {
     const currentYear = new Date().getFullYear();
     const startYear = Math.min(currentYear, yearValue);
     const endYear = Math.max(currentYear, yearValue)
-    for (let i = startYear; i < endYear + 2; i++) {
-      yearInputObject.options.push({
-        text: '' + i,
-        value: i,
-      });
-    }
+    if (yearInputObject.options.length <= 0) {
+      for (let i = startYear; i < endYear + 2; i++) {
+        yearInputObject.options.push({
+          text: '' + i,
+          value: i,
+        });
+      }
+    };
   }
 
   /**
@@ -727,12 +729,14 @@ export class IirisMaintenanceModal extends PureComponent<Props, State> {
   populateMonthSelector = (monthInputObject: any, monthValue: number) => {
     monthInputObject.value = monthValue;
     monthInputObject.text = '' + monthValue;
-    for (let i = 1; i < 13; i++) {
-      monthInputObject.options.push({
-        text: '' + i,
-        value: i,
-      });
-    }
+    if (monthInputObject.options.length <= 0) {
+      for (let i = 1; i < 13; i++) {
+        monthInputObject.options.push({
+          text: '' + i,
+          value: i,
+        });
+      }
+    };
   }
 
   /**
@@ -783,12 +787,14 @@ export class IirisMaintenanceModal extends PureComponent<Props, State> {
    * Set contents of month selector
    */
   populateHourSelector = (hourInputObject: any, hourValue: number) => {
-    for (let i = 0; i < 24; i++) {
-      hourInputObject.options.push({
-        text: '' + i,
-        value: '' + i,
-      });
-    }
+    if (hourInputObject.options <= 0) {
+      for (let i = 0; i < 24; i++) {
+        hourInputObject.options.push({
+          text: '' + i,
+          value: '' + i,
+        });
+      }
+    };
     if (hourInputObject.options.findIndex((item: any) => item.value === hourValue + '')) {
       hourInputObject.value = hourValue + '';
     } else {
@@ -801,12 +807,14 @@ export class IirisMaintenanceModal extends PureComponent<Props, State> {
    * Set contents of month selector
    */
   populateMinuteSelector = (minuteInputObject: any, minuteValue: number) => {
-    for (let i = 0; i < 60; i++) {
-      minuteInputObject.options.push({
-        text: '' + i,
-        value: '' + i,
-      });
-    }
+    if (minuteInputObject.options.length <= 0) {
+      for (let i = 0; i < 60; i++) {
+        minuteInputObject.options.push({
+          text: '' + i,
+          value: '' + i,
+        });
+      }
+    };
     const givenMinutes = '' + minuteValue;
     if (minuteInputObject.options.findIndex((item: any) => item.value === givenMinutes)) {
       minuteInputObject.value = givenMinutes;


### PR DESCRIPTION
Apparently something triggers these selections' populating methods multiple times. I couldn't figure out what was causing this behavior and I assume that is supposed to happen because otherwise the day selector wouldn't be able to populate days correctly (different months have different amount of days).

So anyways, if the options already have the numbers populated, these methods will add more numbers to options! This results in errors like:
```
Warning: Encountered two children with the same key, `smi59`. Keys should be unique so that components maintain their identity across updates...
```

The day selection is not affected by this bug since the options for days are emptied out before re-populating.