### PR TITLE
IISCRUM-2997, Maintenances, removable maintenance datasource and host…

### DIFF
--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
@@ -77,14 +77,12 @@ export function GeneralSettingsUnconnected({
     const datasourceSrv = getDatasourceSrv();
     const datasources: any[] = [];
     datasourceSrv.getMetricSources().map((datasource: { name: string }) => datasources.push(datasource.name));
+    datasources.unshift('');
     setDatasourceOptions(datasources);
     const availableDatasources = datasourceSrv
       .getMetricSources()
       .filter((datasource: any) => datasource.meta.id.indexOf('zabbix-datasource') > -1 && datasource.value)
       .map((ds: any) => ds.name);
-    if (!dashboard.selectedDatasource && availableDatasources.length > 0) {
-      dashboard.selectedDatasource = availableDatasources[0];
-    }
     const dsPointer = dashboard.selectedDatasource ? [dashboard.selectedDatasource] : availableDatasources;
     getHostGroups(dsPointer, datasourceSrv).then((groups: string[]) => setHostGroupOptions(groups));
   }, []);
@@ -145,16 +143,24 @@ export function GeneralSettingsUnconnected({
   };
 
   const onMaintenanceDatasourceChange = (datasource: any) => {
-    dashboard.selectedDatasource = datasource.value;
-    setRenderCounter(renderCounter + 1);
-    const datasourceSrv = getDatasourceSrv();
-    if (datasourceOptions.indexOf(dashboard.selectedDatasource) > -1) {
-      getHostGroups([dashboard.selectedDatasource], datasourceSrv)
-        .then((groups: string[]) => setHostGroupOptions(groups))
-        .catch((err: any) => {
-          setHostGroupOptions([]);
-        });
+    if (datasource != null) {
+      dashboard.selectedDatasource = datasource.value;
+      setRenderCounter(renderCounter + 1);
+      const datasourceSrv = getDatasourceSrv();
+      if (datasourceOptions.indexOf(dashboard.selectedDatasource) > -1) {
+        getHostGroups([dashboard.selectedDatasource], datasourceSrv)
+          .then((groups: string[]) => setHostGroupOptions(groups))
+          .catch((err: any) => {
+            setHostGroupOptions([]);
+          });
+      }
     }
+    else {
+      dashboard.selectedDatasource = '';
+      dashboard.maintenanceHostGroup = '';
+      setRenderCounter(renderCounter + 1);
+      setHostGroupOptions([]);
+    };
   };
 
   const onMaintenanceHostGroupChange = (hostgroup: any) => {
@@ -195,7 +201,8 @@ export function GeneralSettingsUnconnected({
             placeholder="Select datasource"
             value={dashboard.selectedDatasource}
             onChange={onMaintenanceDatasourceChange}
-          />
+            isClearable={true}
+        />
         </Field>
         <Field label="Maintenance Host Group">
           <Select


### PR DESCRIPTION
There was specific code that kept sure that there is always a datasource selected for a dashboard:
https://github.com/digiaiiris/grafana/blob/74cf9b36f6424ef65f464da1a9dc9689197fd0f4/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx#L85

Which has been added in the Grafana 8 update's pull request:
https://github.com/digiaiiris/grafana/commit/68a8f39d870e9a7f202fe6158e647481953ff3c4#diff-668f5fb4bbade01d5f3781261fd478820eb600ff77f7a7bc5e9289621f4998a5

So once again I assume this won't break anything, but there might be a reason why there should always be a datasource selected for a dashboard...