### PR TITLE
IISCRUM-2985: Responsivity fix to modal style

### DIFF
--- a/public/sass/iiris_custom_modal.scss
+++ b/public/sass/iiris_custom_modal.scss
@@ -16,6 +16,7 @@ div[role='dialog'].modal,
 
 div[role='dialog'].modal-body > div:nth-child(2) {
   padding: 0;
+  max-height: 90vh;
 }
 
 .modal-body {

--- a/public/sass/iiris_event_table.scss
+++ b/public/sass/iiris_event_table.scss
@@ -4,12 +4,11 @@ $iiris-table-vertical-padding: 6px;
 $iiris-table-horizontal-padding: 10px;
 
 .iiris-table-container {
-  height: 100%;
+  max-height: calc(90vh - 180px);
+  overflow-y: auto;
 }
 
 .iiris-event-table {
-  height: 100%;
-  overflow-y: scroll;
   .table {
     width: 100%;
     tr {


### PR DESCRIPTION
These style changes should help to keep maintenance modal buttons visible even with small screen heights and long list of different maintenances. Had to remove some old styling codes as they created scrollbars inside scrollbars.